### PR TITLE
Add n8n workflow integration client

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,37 @@ Each feature directory represents a core module of the Kartra platform and inclu
    pytest
    ```
 
+## n8n Integration
+Kartra can use [n8n](https://n8n.io) for external workflow automation.
+
+### Deploy an n8n Instance
+Run a local instance with Docker:
+```bash
+docker run -it --rm -p 5678:5678 n8nio/n8n
+```
+Alternatively, sign up for the hosted n8n Cloud service.
+
+### Obtain an API Key
+In the n8n dashboard navigate to **Settings → API**, enable the API and copy the generated key.
+
+### Configure Environment Variables
+Point the app to your n8n server by setting the following variables:
+```bash
+export N8N_BASE_URL=http://localhost:5678
+export N8N_API_KEY=your-api-key
+export N8N_EXAMPLE_WORKFLOW_ID=<workflow-id>
+```
+Define additional variables for any other workflow IDs your application triggers.
+
+### Trigger Workflows
+Use the helper in `src/integrations/n8n_client.py`:
+```python
+from src.integrations import n8n_client
+
+n8n_client.trigger_workflow(N8N_EXAMPLE_WORKFLOW_ID, {"foo": "bar"})
+```
+The `requests` dependency required for this integration has been added to `requirements.txt`.
+
 ## Contributing
 1. Fork the repository and create your branch from `main`.
 2. Make changes and add tests where applicable.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 pytest>=8.0.0
+
+requests>=2.31.0

--- a/src/integrations/n8n_client.py
+++ b/src/integrations/n8n_client.py
@@ -1,0 +1,55 @@
+"""Client utilities for interacting with n8n workflows."""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Tuple
+
+import requests
+
+
+def _get_config() -> Tuple[str, str]:
+    """Return the n8n base URL and API key from environment variables."""
+    base_url = os.getenv("N8N_BASE_URL")
+    api_key = os.getenv("N8N_API_KEY")
+    if not base_url or not api_key:
+        raise ValueError("N8N_BASE_URL and N8N_API_KEY must be set")
+    return base_url, api_key
+
+
+def trigger_workflow(workflow_id: str, payload: Dict[str, Any]) -> requests.Response:
+    """Trigger an n8n workflow with the given payload.
+
+    Parameters
+    ----------
+    workflow_id:
+        The ID of the workflow to execute.
+    payload:
+        Data to send to the workflow.
+
+    Returns
+    -------
+    requests.Response
+        The response returned by the n8n server.
+
+    Raises
+    ------
+    ValueError
+        If required configuration variables are missing.
+    requests.HTTPError
+        If the HTTP request fails.
+    """
+    base_url, api_key = _get_config()
+
+    url = f"{base_url}/api/v1/workflows/{workflow_id}/run"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    response = requests.post(url, json=payload, headers=headers, timeout=30)
+    response.raise_for_status()
+    return response
+
+
+def trigger_default_workflow(payload: Dict[str, Any]) -> requests.Response:
+    """Trigger the workflow referenced by ``N8N_EXAMPLE_WORKFLOW_ID``."""
+    workflow_id = os.getenv("N8N_EXAMPLE_WORKFLOW_ID")
+    if not workflow_id:
+        raise ValueError("N8N_EXAMPLE_WORKFLOW_ID must be set")
+    return trigger_workflow(workflow_id, payload)

--- a/tests/integrations/test_n8n_client.py
+++ b/tests/integrations/test_n8n_client.py
@@ -1,0 +1,62 @@
+"""Tests for the n8n client integration."""
+import pathlib
+import sys
+import types
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))
+from integrations import n8n_client
+
+
+def test_trigger_workflow_missing_env(monkeypatch):
+    monkeypatch.delenv("N8N_BASE_URL", raising=False)
+    monkeypatch.delenv("N8N_API_KEY", raising=False)
+    with pytest.raises(ValueError):
+        n8n_client.trigger_workflow("123", {})
+
+
+def test_trigger_workflow_success(monkeypatch):
+    monkeypatch.setenv("N8N_BASE_URL", "http://example.com")
+    monkeypatch.setenv("N8N_API_KEY", "secret")
+
+    called = {}
+
+    def fake_post(url, json, headers, timeout):  # type: ignore[override]
+        called["url"] = url
+        called["json"] = json
+        called["headers"] = headers
+        response = types.SimpleNamespace()
+        response.raise_for_status = lambda: None
+        return response
+
+    monkeypatch.setattr(n8n_client.requests, "post", fake_post)
+
+    response = n8n_client.trigger_workflow("1", {"foo": "bar"})
+    assert hasattr(response, "raise_for_status")
+    assert called["url"] == "http://example.com/api/v1/workflows/1/run"
+    assert called["json"] == {"foo": "bar"}
+    assert called["headers"]["Authorization"] == "Bearer secret"
+
+
+def test_trigger_default_workflow(monkeypatch):
+    monkeypatch.setenv("N8N_BASE_URL", "http://example.com")
+    monkeypatch.setenv("N8N_API_KEY", "secret")
+    monkeypatch.setenv("N8N_EXAMPLE_WORKFLOW_ID", "2")
+
+    called = {}
+
+    def fake_post(url, json, headers, timeout):  # type: ignore[override]
+        called["url"] = url
+        called["json"] = json
+        called["headers"] = headers
+        response = types.SimpleNamespace()
+        response.raise_for_status = lambda: None
+        return response
+
+    monkeypatch.setattr(n8n_client.requests, "post", fake_post)
+
+    response = n8n_client.trigger_default_workflow({"bar": "baz"})
+    assert hasattr(response, "raise_for_status")
+    assert called["url"] == "http://example.com/api/v1/workflows/2/run"
+    assert called["json"] == {"bar": "baz"}


### PR DESCRIPTION
## Summary
- document n8n deployment and configuration
- add n8n client for triggering workflows
- test n8n client and add requests dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d00d18cb48329ad26141cfd8be9ef